### PR TITLE
FIX: from loaded to mutation observer

### DIFF
--- a/cdn/index.js
+++ b/cdn/index.js
@@ -27,4 +27,4 @@ const story_title_observer = new MutationObserver((mutList) => {
   }
 })
 
-story_title_observer.observe(dynamic_lists,)
+story_title_observer.observe(dynamic_lists, config)

--- a/cdn/index.js
+++ b/cdn/index.js
@@ -11,13 +11,20 @@ function manageColorContrasts() {
   }
 };
 
-const globalFunctions = {
-  manageColorContrasts
-}
-
-
-document.addEventListener("DOMContentLoaded", function () {
-  for (let key in globalFunctions) {
-    globalFunctions[key]()
+/**
+ * Webflow cms list content is lazy loaded.
+ * This requires us to use a mutation observer to watch for lazy-loaded content.
+ * When the content changes, the contrast function is re-run.
+ */
+const dynamic_lists = document.querySelector(".dynam-list")
+const config = { childList: true, subtree: true }
+const story_title_observer = new MutationObserver((mutList) => {
+  for (let mut of mutList) {
+    // check if element has been added
+    if (mut.addedNodes.length) {
+      manageColorContrasts()
+    }
   }
 })
+
+story_title_observer.observe(dynamic_lists,)


### PR DESCRIPTION
# Mutation Observer
Webflow lazy loads content, so use a mutation observer to listen for new content to rerun the function. 

Maybe I should just delay the initial run of the function until content is loaded totally? 